### PR TITLE
fix: bump older rubocop due to vulnerability

### DIFF
--- a/blockbuster.gemspec
+++ b/blockbuster.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'mocha'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rubocop', '~> 0.37'
+  spec.add_development_dependency 'rubocop', '~> 0.49'
 end


### PR DESCRIPTION
WYSIWYG