### PR TITLE
ignore errors when wiping cassettes directory

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,7 @@ LineLength:
   Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: false
+Metrics/BlockLength:
+  Enabled: false
+Naming/VariableNumber:
+  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -10,8 +10,8 @@ end
 
 desc 'Run rubocop'
 RuboCop::RakeTask.new do |task|
-  task.options       = %w(--display-cop-names)
-  task.formatters    = %w(fuubar)
+  task.options       = %w[--display-cop-names]
+  task.formatters    = %w[fuubar]
   task.fail_on_error = true
 end
 

--- a/blockbuster.gemspec
+++ b/blockbuster.gemspec
@@ -1,5 +1,4 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'blockbuster/version'
 

--- a/lib/blockbuster/concerns/extractor.rb
+++ b/lib/blockbuster/concerns/extractor.rb
@@ -3,6 +3,7 @@ module Blockbuster
   module Extractor
     def extract_cassettes
       return unless File.exist?(file_path)
+
       File.open(file_path, 'rb') do |file|
         Zlib::GzipReader.wrap(file) do |gz|
           Gem::Package::TarReader.new(gz) do |tar|

--- a/lib/blockbuster/delta.rb
+++ b/lib/blockbuster/delta.rb
@@ -4,7 +4,7 @@ module Blockbuster
     include Blockbuster::Extractor
     include Blockbuster::Packager
 
-    attr_reader :current, :file_name, :configuration
+    attr_reader :file_name, :configuration
 
     # nodoc
     class NotEnabledError < StandardError

--- a/lib/blockbuster/manager.rb
+++ b/lib/blockbuster/manager.rb
@@ -57,7 +57,7 @@ module Blockbuster
       dir = configuration.cassette_dir
 
       silent_puts "Wiping cassettes directory: #{dir}"
-      FileUtils.rm_r(dir) if Dir.exist?(dir)
+      FileUtils.rm_rf(dir) if Dir.exist?(dir)
     end
   end
 end

--- a/lib/blockbuster/manager.rb
+++ b/lib/blockbuster/manager.rb
@@ -40,10 +40,10 @@ module Blockbuster
 
     # repackages cassettes into a compressed tarball
     def drop_off(force: false)
-      if comparator.rewind?(configuration.cassette_files) || force
-        silent_puts "Recreating cassette file #{@extraction_list.primary.target_path}"
-        @extraction_list.primary.create_cassette_file
-      end
+      return unless comparator.rewind?(configuration.cassette_files) || force
+
+      silent_puts "Recreating cassette file #{@extraction_list.primary.target_path}"
+      @extraction_list.primary.create_cassette_file
     end
 
     alias setup rent

--- a/lib/blockbuster/version.rb
+++ b/lib/blockbuster/version.rb
@@ -1,3 +1,3 @@
 module Blockbuster
-  VERSION = '0.4.1'.freeze
+  VERSION = '0.5.0'.freeze
 end

--- a/spec/blockbuster/comparator_spec.rb
+++ b/spec/blockbuster/comparator_spec.rb
@@ -43,7 +43,7 @@ describe Blockbuster::Comparator do
       instance.add('a', 'b', 'c')
       instance.add('b', 'c', 'd')
       instance.keys.size.must_be :>, 0
-      instance.keys.sort.must_equal %w(a b)
+      instance.keys.sort.must_equal %w[a b]
     end
   end
 
@@ -62,7 +62,7 @@ describe Blockbuster::Comparator do
 
   describe '#compare' do
     it 'returns true if first argument does not exist as hash key' do
-      instance.keys.include?('fakekey').must_equal false
+      instance.keys.include?('fakekey').must_equal false # rubocop:disable Performance/InefficientHashSearch
 
       instance.compare('fakekey', 'blah').must_equal true
     end
@@ -148,7 +148,7 @@ describe Blockbuster::Comparator do
       end
 
       it 'returns true if there are any items in the `deleted` queue' do
-        instance.instance_variable_set(:@deleted, %w(a))
+        instance.instance_variable_set(:@deleted, %w[a])
 
         instance.any_deleted?.must_equal true
       end
@@ -166,8 +166,8 @@ describe Blockbuster::Comparator do
       end
 
       it 'returns true if intersection of `current_delta_files` and `deleted` is not empty' do
-        instance.instance_variable_set(:@current_delta_files, %w(a b))
-        instance.instance_variable_set(:@deleted, %w(b))
+        instance.instance_variable_set(:@current_delta_files, %w[a b])
+        instance.instance_variable_set(:@deleted, %w[b])
 
         (instance.current_delta_files & instance.deleted).wont_be :empty?
 

--- a/spec/blockbuster/configuration_spec.rb
+++ b/spec/blockbuster/configuration_spec.rb
@@ -9,16 +9,16 @@ describe Blockbuster::Configuration do
   end
 
   it 'has configuration attributes' do
-    attrs = [
-      :cassette_directory,
-      :master_tar_file,
-      :local_mode,
-      :test_directory,
-      :wipe_cassette_dir,
-      :silent,
-      :enable_deltas,
-      :delta_directory,
-      :current_delta_name
+    attrs = %i[
+      cassette_directory
+      master_tar_file
+      local_mode
+      test_directory
+      wipe_cassette_dir
+      silent
+      enable_deltas
+      delta_directory
+      current_delta_name
     ]
 
     attrs.each do |attr|

--- a/spec/blockbuster/manager_spec.rb
+++ b/spec/blockbuster/manager_spec.rb
@@ -146,7 +146,7 @@ describe Blockbuster::Manager do
       end
 
       it 'creates a new cassette file if rewind? is true' do
-        open(cassette_2, 'a') do |file|
+        open(cassette_2, 'a') do |file| # rubocop:disable Security/Open
           file << 'new recording'
         end
 
@@ -169,7 +169,7 @@ describe Blockbuster::Manager do
       end
 
       it 'returns true if a cassette file was changed' do
-        open(cassette_2, 'a') do |file|
+        open(cassette_2, 'a') do |file| # rubocop:disable Security/Open
           file << 'new recording'
         end
 

--- a/spec/integration/delta_feature_spec.rb
+++ b/spec/integration/delta_feature_spec.rb
@@ -202,14 +202,14 @@ describe 'DeltaFeature' do
       config.current_delta_name = 'delta_a.tar.gz'
 
       manager.rent
-      first_rent = YAML.load(File.open("#{config.cassette_dir}/test_a.yml"))
+      first_rent = YAML.safe_load(File.open("#{config.cassette_dir}/test_a.yml"))
       File.truncate("#{config.cassette_dir}/test_b.yml", 1)
       manager.drop_off
 
       FileUtils.rm_r("#{unique_dir}/cassettes")
       manager_2 = Blockbuster::Manager.new(config)
       manager_2.rent
-      second_rent = YAML.load(File.open("#{config.cassette_dir}/test_a.yml"))
+      second_rent = YAML.safe_load(File.open("#{config.cassette_dir}/test_a.yml"))
 
       first_rent.must_equal second_rent
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'pry'
 require 'blockbuster'
 


### PR DESCRIPTION
this uses rm_rf instead of rm_r so that errors are ignored when wiping
the test/cassettes directory. this allows us to use a tmpfs mount for
this directory in docker, drastically speeding up test times